### PR TITLE
Fix HA addon install: add missing build.yaml

### DIFF
--- a/mmwave_vis/build.yaml
+++ b/mmwave_vis/build.yaml
@@ -1,0 +1,3 @@
+build_from:
+  aarch64: ghcr.io/home-assistant/aarch64-base:3.21
+  amd64: ghcr.io/home-assistant/amd64-base:3.21


### PR DESCRIPTION
## Summary
HA supervisor failed to install the addon with:
\`\`\`
InvalidDefaultArgInFrom: Default value for ARG \$BUILD_FROM results in empty or invalid base image name (line 2)
ERROR: failed to build: failed to solve: base name (\$BUILD_FROM) should not be blank
\`\`\`

Without \`build.yaml\`, the supervisor doesn't know which base image to pass as \`BUILD_FROM\`, and newer BuildKit versions no longer silently accept the empty ARG.

Pin the official HA Alpine base per arch — matches \`config.yaml\` (\`aarch64\`, \`amd64\`) and the Dockerfile's \`apk add python3 py3-pip\`.

## Test plan
- [ ] Reinstall the addon in HA after merge — build should succeed and the addon should start

🤖 Generated with [Claude Code](https://claude.com/claude-code)