### PR TITLE
Auto-dispatch docker build from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      actions: write
 
     steps:
       - uses: actions/checkout@v4
@@ -54,3 +55,16 @@ jobs:
           tag_name: v${{ steps.version.outputs.version }}
           name: v${{ steps.version.outputs.version }}
           body: ${{ steps.changelog.outputs.body }}
+
+      # Tag pushes performed by the default GITHUB_TOKEN do NOT trigger the
+      # docker workflow's `push: tags` trigger (downstream-workflow safeguard).
+      # workflow_dispatch IS exempt from that safeguard, so kick off the
+      # Docker build explicitly here. See docs:
+      # https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow
+      - name: Trigger Docker image build
+        if: steps.check_tag.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          gh workflow run docker.yml --ref main -f tag="v${VERSION}"


### PR DESCRIPTION
## Summary
- Release workflow now invokes the Docker build workflow via `gh workflow run` at the end of the release job.
- Closes the long-standing gap where GITHUB_TOKEN-driven tag pushes from release.yml never triggered `docker.yml`'s `push: tags` handler (GitHub's recursive-workflow safeguard).

## Why this works
`workflow_dispatch` is explicitly exempt from the downstream-workflow restriction that applies to `push`/`release` events triggered by the default token. Passing `-f tag=v<version>` reuses the existing `tag` input added in v3.2.1 so the correct ref is checked out and the image is labelled `:v<version>` + `:latest`.

## Changes
- `.github/workflows/release.yml`
  - Added `actions: write` permission (required for `gh workflow run`)
  - New "Trigger Docker image build" step gated on the new-tag path

## Test plan
- [ ] Merge this PR
- [ ] Cut v3.2.2 via config.yaml bump
- [ ] Confirm release.yml creates tag + release AND immediately fires docker.yml
- [ ] Confirm `ghcr.io/nickduvall921/mmwave_vis:v3.2.2` and `:latest` are public

🤖 Generated with [Claude Code](https://claude.com/claude-code)