### PR TITLE
Fix live target tracking on Z2M 2.9+ (v3.2.2)

### DIFF
--- a/mmwave_vis/CHANGELOG.md
+++ b/mmwave_vis/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
 
+## [3.2.2] - 2026-04-16
+
+### Fixed
+- **Live target tracking still empty / jumpy on Z2M 2.9.x+ (follow-up to 3.2.1):** when Z2M publishes a state message, it contains *both* the parsed `mmwave_targets` array *and* the legacy raw ZCL byte keys (`"0": 29, "1": 47, "2": 18, ...`). In Z2M 2.9+ the raw-byte layout at offset ≥ 6 is no longer the legacy target-report format, so decoding it yields garbage coordinates. Worse, the raw path ran first and claimed the shared 10 Hz throttle slot, silently dropping the correct parsed emit that 3.2.1 added. `on_message` now skips the raw `_process_target_data` call whenever parsed `mmwave_targets` is present in the same payload, letting the parsed path be authoritative. Zone decoding (cmd_id 2/3/4) is unaffected.
+
+### Changed
+- Bumped version to 3.2.2.
+
 ## [3.2.1] - 2026-04-16
 
 ### Fixed

--- a/mmwave_vis/app.py
+++ b/mmwave_vis/app.py
@@ -433,10 +433,20 @@ class Z2MDriver:
                 device_topic = self.device_list[fname]['topic']
 
             # --- Raw ZCL byte packets (cluster 0xFC32) ---
+            # Z2M 2.9+ publishes a top-level parsed `mmwave_targets` array
+            # AND still leaves the raw ZCL bytes in numbered keys of the
+            # same message. In 2.9 the byte layout at offset >=6 no longer
+            # matches the legacy format, so decoding it yields garbage
+            # coordinates. Worse, because it runs first it claims the 10 Hz
+            # throttle slot and the correct parsed path (handled in
+            # _process_state_update) gets silently dropped. Skip the raw
+            # target decode whenever parsed targets are present and let the
+            # parsed path be authoritative.
+            has_parsed_targets = isinstance(payload.get("mmwave_targets"), list)
             is_raw = (payload.get("0") == 29 and payload.get("1") == 47 and payload.get("2") == 18)
             if is_raw:
                 cmd_id = payload.get("4")
-                if cmd_id == 1:
+                if cmd_id == 1 and not has_parsed_targets:
                     try:
                         self._process_target_data(payload, fname, device_topic)
                     except Exception as e:

--- a/mmwave_vis/config.yaml
+++ b/mmwave_vis/config.yaml
@@ -1,6 +1,6 @@
 name: "Inovelli mmWave Visualizer"
 description: "Live 2D tracking for Inovelli mmWave switches via MQTT-Z2M or ZHA"
-version: "3.2.1"
+version: "3.2.2"
 slug: "mmwave_viz"
 init: false
 arch:


### PR DESCRIPTION
## Summary
Follow-up to 3.2.1. Live tracking still didn't render targets on Z2M 2.9+ because the parsed `mmwave_targets` emit added in 3.2.1 was silently dropped by the legacy raw-bytes path running first on the same message.

## Root cause
Z2M 2.9+ state messages contain **both** the parsed field AND the legacy numbered-byte keys in the same payload:
```json
{
  "0": 29, "1": 47, "2": 18, ...,
  "mmwave_targets": [{"id": 3, "x": 26, "y": 75, "z": -28, "dop": 0}]
}
```
In Z2M 2.9 the raw-byte layout at offset >= 6 is not the legacy target-report format anymore, so decoding yields garbage coords (real `{id:3,x:26,y:75,z:-28}` decoded as `{id:1,x:-117,y:406,z:4}`). Worse, because the raw path runs first it claims the shared 10 Hz throttle slot in `_emit_targets`, silently dropping the correct parsed emit.

## Fix
Skip `_process_target_data` whenever parsed `mmwave_targets` is present in the same payload — let the parsed path be authoritative. Zone decoding (cmd_id 2/3/4) is unaffected.

## Test plan
- [ ] Verify frontend radar now renders the parsed target id=3 at (26, 75) with z=-28.
- [ ] Confirm pre-2.9 Z2M installs still work (payload has raw keys only, no `mmwave_targets`, so raw path still runs).
- [ ] Release workflow creates v3.2.2 tag + release; auto-dispatch (PR #35) fires docker build; image publishes to GHCR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)