### PR TITLE
Fix Zone 1 occupancy not displayed (issue #26)

### DIFF
--- a/mmwave_vis/templates/index.html
+++ b/mmwave_vis/templates/index.html
@@ -352,7 +352,7 @@
             <div class="config-group" style="background: #1e1e1e; border-color: #00bcd4;">
                 <div class="config-title" style="color: #00bcd4;">Live Sensors</div>
                 <div class="sensor-row">
-                    <span style="color: #ccc;">Area 1 (Primary):</span>
+                    <span style="color: #ccc;">Global Occupancy:</span>
                     <span id="occupancyVal" class="sensor-val badge-clear">Waiting...</span>
                 </div>
                 <div class="sensor-row">
@@ -368,6 +368,10 @@
             <details open class="mobile-collapsed" id="zoneStatusSection">
                 <summary>Zone Status</summary>
                 <div class="config-content">
+                    <div class="sensor-row">
+                        <span style="color: #ccc;">Area 1:</span>
+                        <span id="area1Val" class="zone-badge">CLEAR</span>
+                    </div>
                     <div class="sensor-row">
                         <span style="color: #ccc;">Area 2:</span>
                         <span id="area2Val" class="zone-badge">CLEAR</span>


### PR DESCRIPTION
The "Area 1 (Primary)" label under Live Sensors was wired to global occupancy (OR of all zones) rather than Zone 1's actual status, and no HTML element existed for Zone 1 in the Zone Status section.

- Relabel "Area 1 (Primary)" to "Global Occupancy" to reflect what it actually shows
- Add area1Val element to the Zone Status section — the existing JS loop already updates area1Val..area4Val from mmwave_area{i}_occupancy

Closes #26.

https://claude.ai/code/session_01ST52QD9Td63Mi57C18oSvV