### PR TITLE
Release 3.2.3 — Zone 1 occupancy fix

### DIFF
--- a/mmwave_vis/CHANGELOG.md
+++ b/mmwave_vis/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
 
+## [3.2.3] - 2026-04-23
+
+### Fixed
+- **Issue #26 — Zone 1 occupancy not displayed:** the "Area 1 (Primary)" row under Live Sensors was actually wired to the device's global `occupancy` attribute (OR of all zones), and no `area1Val` element existed in the Zone Status section — so the JS loop that updates `area{1..4}Val` from `mmwave_area{i}_occupancy` silently skipped Zone 1. Relabeled the Live Sensors row to "Global Occupancy" (accurate to what it shows) and added the missing `area1Val` element so Zone 1's real per-area occupancy now renders alongside Zones 2–4.
+
+### Changed
+- Bumped version to 3.2.3.
+
 ## [3.2.2] - 2026-04-16
 
 ### Fixed

--- a/mmwave_vis/config.yaml
+++ b/mmwave_vis/config.yaml
@@ -1,6 +1,6 @@
 name: "Inovelli mmWave Visualizer"
 description: "Live 2D tracking for Inovelli mmWave switches via MQTT-Z2M or ZHA"
-version: "3.2.2"
+version: "3.2.3"
 slug: "mmwave_viz"
 init: false
 arch:


### PR DESCRIPTION
## Summary
Ships the issue #26 fix (PR #38) to addon and Docker users.

## Changes included
- `mmwave_vis/templates/index.html` (from PR #38):
  - "Area 1 (Primary)" → "Global Occupancy" under Live Sensors
  - New `area1Val` span under Zone Status so Zone 1 actually renders

## Release plan
- Merge → release.yml creates v3.2.3 tag + GitHub release + auto-dispatches docker.yml → image publishes to `ghcr.io/nickduvall921/mmwave_vis:v3.2.3` + `:latest`.
- This is the second real-world validation of the auto-dispatch pipeline (PR #35).

Closes #26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)