### PR TITLE
Fix legacy raw target decoder stride (3.2.4)

### DIFF
--- a/mmwave_vis/CHANGELOG.md
+++ b/mmwave_vis/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
 
+## [3.2.4] - 2026-04-23
+
+### Fixed
+- **Legacy raw-bytes target decoder used wrong 9-byte stride (mirrors upstream Z2M bug fixed in [Koenkk/zigbee-herdsman-converters#11915](https://github.com/Koenkk/zigbee-herdsman-converters/pull/11915), 2026-04-11):** the Inovelli `0xFC32` cluster's `reportTargetInfo` records are 10 bytes each (`x, y, z, dop, id` as little-endian int16), not 9 bytes with a uint8 id. Z2M had the same bug until herdsman PR #11915 corrected the stride and stopped clamping the ID to 0–255. Updated `_process_target_data` to match: stride 10, `id` parsed as int16LE. This path is dormant on Z2M ≥ 2.9 (3.2.2 already gates it off whenever parsed `mmwave_targets` is present), but pre-2.9 Z2M users who relied on the raw fallback now get correct coordinates for every target instead of garbage on target #2+.
+
+### Changed
+- Bumped version to 3.2.4.
+
 ## [3.2.3] - 2026-04-23
 
 ### Fixed

--- a/mmwave_vis/app.py
+++ b/mmwave_vis/app.py
@@ -490,23 +490,33 @@ class Z2MDriver:
         )
 
     def _process_target_data(self, payload, fname, device_topic):
+        # Legacy raw-bytes path for pre-2.9 Z2M (no top-level mmwave_targets).
+        # Each target is a 10-byte record matching the upstream Inovelli FC32
+        # cluster reportTargetInfo command — five little-endian int16s in order
+        # x, y, z, dop, id. Z2M itself was using a 9-byte stride with a uint8 id
+        # until herdsman-converters PR #11915 (merged 2026-04-11), which caused
+        # any target after the first to be reported with garbage coordinates.
+        # Mirror the upstream fix here so users on older Z2M (pre-PR #11915 or
+        # pre-2.9 entirely) get correct coords for multi-target frames.
         num_targets = safe_int(payload.get("5"), 0)
         if not (0 <= num_targets <= 10):
             return
 
         targets = []
         offset  = 6
+        stride  = 10
         for _ in range(num_targets):
-            if str(offset + 8) not in payload:
+            # Need 10 bytes (offset .. offset+9)
+            if str(offset + 9) not in payload:
                 break
             targets.append({
-                "id":  safe_int(payload.get(str(offset + 8)), 0),
                 "x":   parse_signed_16(payload, offset),
                 "y":   parse_signed_16(payload, offset + 2),
                 "z":   parse_signed_16(payload, offset + 4),
                 "dop": parse_signed_16(payload, offset + 6),
+                "id":  parse_signed_16(payload, offset + 8),
             })
-            offset += 9
+            offset += stride
 
         self._emit_targets(targets, fname, device_topic, seq=payload.get("3"))
 

--- a/mmwave_vis/config.yaml
+++ b/mmwave_vis/config.yaml
@@ -1,6 +1,6 @@
 name: "Inovelli mmWave Visualizer"
 description: "Live 2D tracking for Inovelli mmWave switches via MQTT-Z2M or ZHA"
-version: "3.2.3"
+version: "3.2.4"
 slug: "mmwave_viz"
 init: false
 arch:


### PR DESCRIPTION
## Summary
Mirrors the upstream Z2M fix from [Koenkk/zigbee-herdsman-converters#11915](https://github.com/Koenkk/zigbee-herdsman-converters/pull/11915) (merged 2026-04-11). The Inovelli \`0xFC32\` \`reportTargetInfo\` records are 10-byte structs, not 9 — each is five little-endian int16s: \`x, y, z, dop, id\`. Our \`_process_target_data\` had the same bug Z2M just fixed.

## Impact
- **Modern Z2M users (≥ 2.9 with PR #11915):** zero behavioural change — 3.2.2 gates this raw-bytes path off whenever parsed \`mmwave_targets\` is in the payload.
- **Pre-2.9 Z2M users (or any Z2M build older than 2026-04-11):** target #2 and beyond now decode with correct coordinates instead of garbage. Single-target frames were already fine.

## Changes
- \`mmwave_vis/app.py\`: stride 9 → 10, \`id\` parsed as int16LE via \`parse_signed_16\` (matches upstream's removal of the 0-255 clamp), bounds check tightened to need all 10 bytes.
- Version bump 3.2.3 → 3.2.4 + changelog entry.

## Release plan
Merge → release.yml tags v3.2.4 → docker.yml auto-dispatches → image publishes to GHCR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)